### PR TITLE
update for react ≥ 15.5

### DIFF
--- a/CornerLabel.js
+++ b/CornerLabel.js
@@ -6,9 +6,9 @@
  */
 
 import React, {
-    PropTypes,
     Component,
 } from 'react'
+import PropTypes from 'prop-types';
 import {
     StyleSheet,
     View,

--- a/CornerLabel.js
+++ b/CornerLabel.js
@@ -8,7 +8,7 @@
 import React, {
     Component,
 } from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import {
     StyleSheet,
     View,


### PR DESCRIPTION
Fix for issue referenced at [[BUG] undefined is not an object (evaluating '_react2.PropTypes.number') #2](https://github.com/react-native-component/react-native-smart-corner-label/issues/2).